### PR TITLE
use relative path instead of absolute system path

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This second behavior, known as _render at compile time_, comes with the benefit 
 |---|:---:|:---:|:---:|---|
 |environmentModulePath|`true`|string|`undefined`| The absolute path or the identifier to the module that exports the `TwingEnvironment` instance that will be used by the loader to compile (and render) the templates at compile time and in the bundle to render them at runtime.|
 |renderContext|`false`|any|`undefined`|If different from `undefined`, enables the _render at compile time_ behavior and serves as context for the rendering of the templates.|
-|withHTMLComments|`false`|boolean|`undefined`|If `true`, templates will render surrounded by `<!-- START: [[resourcePath]] -->` and `<!-- END: [[resourcePath]] -->` HTML comments, where `[[resourcePath]]` is the absolute path of the Twig file in question.|
+|withHTMLComments|`false`|boolean|`undefined`|If `true`, templates will render surrounded by `<!-- START: [[relativePath]] -->` and `<!-- END: [[relativePath]] -->` HTML comments, where `[[relativePath]]` is the path of the Twig file in question relative to the project root directory.|
 
 ## Contributing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {Visitor} from "./visitor";
 const sha256 = require('crypto-js/sha256');
 const hex = require('crypto-js/enc-hex');
 const slash = require('slash');
+const path = require('path');
 
 const validateOptions = require('schema-utils');
 
@@ -61,7 +62,8 @@ export default function (this: loader.LoaderContext, source: string) {
     let withHTMLComments: boolean = options.withHTMLComments;
 
     if (withHTMLComments) {
-        source = `<!-- START: ${resourcePath} -->\n${source || ''}\n<!-- END: ${resourcePath} -->`;
+        const relativePath = path.relative(process.cwd(), resourcePath);
+        source = `<!-- START: ${relativePath} -->\n${source || ''}\n<!-- END: ${relativePath} -->`;
     }
 
     this.addDependency(slash(environmentModulePath));


### PR DESCRIPTION
In the HTML comments, display the Twig file's _relative_ path instead of the absolute system-level path.